### PR TITLE
Fix: Machines cannot be terminated without MachineItem

### DIFF
--- a/src/main/java/io/ib67/astralflow/api/item/machine/MachineItem.java
+++ b/src/main/java/io/ib67/astralflow/api/item/machine/MachineItem.java
@@ -95,6 +95,5 @@ public class MachineItem implements LogicalHolder {
         emptyState.setMachineType(machine.getType().getName());
         var loc = event.getBrokenBlock().getLocation();
         loc.getWorld().dropItemNaturally(loc, item.asItemStack());
-        AstralFlow.getInstance().getMachineManager().terminateAndRemoveMachine(machine);
     }
 }

--- a/src/main/java/io/ib67/astralflow/listener/BlockListener.java
+++ b/src/main/java/io/ib67/astralflow/listener/BlockListener.java
@@ -21,6 +21,7 @@
 
 package io.ib67.astralflow.listener;
 
+import io.ib67.astralflow.AstralFlow;
 import io.ib67.astralflow.api.AstralFlowAPI;
 import io.ib67.astralflow.api.AstralHelper;
 import io.ib67.astralflow.api.events.MachineBlockBreakEvent;
@@ -88,16 +89,19 @@ public final class BlockListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         var clickedBlock = event.getBlock();
         if (flow.getMachineManager().isMachine(clickedBlock)) {
+            var machine = flow.getMachineManager().getAndLoadMachine(clickedBlock.getLocation());
             var evt = MachineBlockBreakEvent.builder()
                     .cancelled(false)
                     .dropItem(false)
                     .block(clickedBlock)
                     .player(event.getPlayer())
-                    .machine(flow.getMachineManager().getAndLoadMachine(clickedBlock.getLocation()))
+                    .machine(machine)
                     .build();
             Bukkit.getPluginManager().callEvent(evt);
             if (evt.isCancelled()) {
                 event.setCancelled(true);
+            } else {
+                AstralFlow.getInstance().getMachineManager().terminateAndRemoveMachine(machine);
             }
             event.setDropItems(evt.isDropItem());
         }

--- a/src/main/java/io/ib67/astralflow/listener/MachineListener.java
+++ b/src/main/java/io/ib67/astralflow/listener/MachineListener.java
@@ -40,7 +40,7 @@ public final class MachineListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
-    private void onBreak_blockItem(MachineBlockBreakEvent event) {
+    private void onBreak(MachineBlockBreakEvent event) {
         var hookEvt = new MachineBreakEvent(event.getMachine(), event.getPlayer(), event.getBlock());
         event.setCancelled(AstralFlow.getInstance().callHooks(HookType.MACHINE_BREAK, hookEvt));
     }


### PR DESCRIPTION
This closes #109 